### PR TITLE
Add explicit labels and move buttons to avoid mistakes

### DIFF
--- a/templates/show_folder.gohtml
+++ b/templates/show_folder.gohtml
@@ -158,14 +158,18 @@
                                         <form action="{{$.PathTo "delete_file" "fileID" .ID}}" method="POST" id="delete-file-{{.ID}}">
                                             <input type="hidden" name="_method" value="DELETE">
                                             {{$.CSRFTag}}
-                                            <button class="btn btn-icon-only btn-link"
+                                            <button class="btn btn-link"
                                                 data-toggle="modal"
                                                 data-target="#confirm-delete-file-{{.ID}}"
                                             >
                                                 <i class="if if-delete"></i>
-                                                <div class="sr-only">Delete file</div>
+                                                <span class="btn-text">Delete</span>
                                             </button>
                                         </form>
+                                        <a class="btn btn-link" href="{{$.PathTo "download_file" "fileID" .ID}}">
+                                            <i class="if if-download"></i>
+                                            <span class="btn-text">Download</span>
+                                        </a>
                                     </div>
                                 </td>
                             </tr>

--- a/templates/show_space.gohtml
+++ b/templates/show_space.gohtml
@@ -151,10 +151,6 @@
                             </td>
                             <td class="table-col-sm-fixed table-col-sm-fixed-right">
                                 <div class="c-button-toolbar flex-nowrap">
-                                    <a class="btn btn-link" href="{{$.PathTo "folder" "folderID" .ID}}">
-                                        <i class="if if-draft"></i>
-                                        <span class="btn-text">Open</span>
-                                    </a>
                                     <form action="{{$.PathTo "delete_folder" "folderID" .ID}}" method="POST" id="delete-folder-{{.ID}}">
                                         <input type="hidden" name="_method" value="DELETE">
                                         {{$.CSRFTag}}
@@ -166,6 +162,10 @@
                                             <span class="btn-text">Delete</span>
                                         </button>
                                     </form>
+                                    <a class="btn btn-link" href="{{$.PathTo "folder" "folderID" .ID}}">
+                                        <i class="if if-draft"></i>
+                                        <span class="btn-text">Open</span>
+                                    </a>
                                 </div>
                             </td>
                         </tr>


### PR DESCRIPTION
From our test:
- If you're not used to using the Dropbox, you don't recognise specific actions
- Buttons need to be consistent in their location