### PR TITLE
Translate everything to EN and remove feedback form

### DIFF
--- a/views/page.qtpl
+++ b/views/page.qtpl
@@ -61,16 +61,16 @@ interface PageView {
                                 <ul class="nav nav-main">
                                     {% if c.User != nil %}
                                     <li class="nav-item">
-                                        <a class="nav-link" href="https://forms.office.com/e/6D3PEnpV9M" target="_blank">
+                                        <a class="nav-link" href="mailto:libservice@ugent.be" target="_blank">
                                             <i class="if if-service"></i>
-                                            <span class="btn-text">Geef feedback</span>
+                                            <span class="btn-text">Ask help</span>
                                         </a>
                                     </li>
                                     {% endif %}
                                     <li class="nav-item">
                                         <a class="nav-link" href="https://www.ugent.be/intranet/nl/op-het-werk/bibliotheek/publieksdiensten/deliverhandleiding" target="_blank">
                                             <i class="if if-book"></i>
-                                            <span class="btn-text">Handleiding</span>
+                                            <span class="btn-text">Manual &ndash; NL</span>
                                         </a>
                                     </li>
                                     <li class="nav-item">

--- a/views/page.qtpl.go
+++ b/views/page.qtpl.go
@@ -142,9 +142,9 @@ func StreamPage(qw422016 *qt422016.Writer, c *ctx.Ctx, v PageView) {
 //line views/page.qtpl:62
 		qw422016.N().S(`
                                     <li class="nav-item">
-                                        <a class="nav-link" href="https://forms.office.com/e/6D3PEnpV9M" target="_blank">
+                                        <a class="nav-link" href="mailto:libservice@ugent.be" target="_blank">
                                             <i class="if if-service"></i>
-                                            <span class="btn-text">Geef feedback</span>
+                                            <span class="btn-text">Ask help</span>
                                         </a>
                                     </li>
                                     `)
@@ -155,7 +155,7 @@ func StreamPage(qw422016 *qt422016.Writer, c *ctx.Ctx, v PageView) {
                                     <li class="nav-item">
                                         <a class="nav-link" href="https://www.ugent.be/intranet/nl/op-het-werk/bibliotheek/publieksdiensten/deliverhandleiding" target="_blank">
                                             <i class="if if-book"></i>
-                                            <span class="btn-text">Handleiding</span>
+                                            <span class="btn-text">Manual &ndash; NL</span>
                                         </a>
                                     </li>
                                     <li class="nav-item">


### PR DESCRIPTION
Better to refer to the manual that it's dutch. Form is now also replaced by a contact link.