### PR TITLE
add example config for mock-oidc-server

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -18,6 +18,9 @@ services:
       DELIVER_OIDC_SECRET: "CHANGEME"
       DELIVER_OIDC_REDIRECT_URL: "http://localhost:3000/auth/callback"
       DELIVER_COOKIE_SECRET: "1234"
+      DELIVER_OIDC_URL: "http://localhost:4000"
+      DELIVER_OIDC_ID: "oidc-client"
+      DELIVER_OIDC_SECRET: "CHANGEME"
     ports:
       - "3000:3000"
     volumes:
@@ -29,6 +32,8 @@ services:
       - sh
       - -c
       - |
+        apk add caddy
+        caddy reverse-proxy --from :4000 --to oidc:4000 &
         npm install
         tern migrate
         reflex -d none -c reflex.conf
@@ -61,3 +66,59 @@ services:
       MINIO_ROOT_PASSWORD: minioadmin
     volumes:
       - ~/tmp/deliver_minio_data:/data
+
+  oidc:
+    image: ugentlib/mock-oidc-server:latest
+    container_name: mock-oidc-server
+    ports:
+      - 4000
+    command: "/bin/sh -c \"cd /dist && ./app server\""
+    environment:
+      MOCK_OIDC_EXPIRES_IN: "3600s"
+      MOCK_OIDC_HOST: "0.0.0.0"
+      MOCK_OIDC_PORT: "4000"
+      MOCK_OIDC_PRODUCTION: "true"
+      MOCK_OIDC_SESSION_COOKIE_NAME: "MOCK_OIDC_SESSION"
+      MOCK_OIDC_URI_BASE: "http://localhost:4000"
+      MOCK_OIDC_USERS: |
+        [
+          {
+            "id": "jdoe",
+            "claims": [
+              {
+                "name":  "name",
+                "value": "John Doe"
+              },
+              {
+                "name":  "given_name",
+                "value": "John"
+              },
+              {
+                "name":  "family_name",
+                "value": "Doe"
+              },
+              {
+                "name":  "preferred_username",
+                "value": "jdoe"
+              },
+              {
+                "name":  "email",
+                "value": "john.doe@ugent.be"
+              }
+            ]
+          }
+        ]
+      MOCK_OIDC_CLIENTS: |
+        [
+          {
+            "id": "oidc-client",
+            "secret": "CHANGEME"
+          }
+        ]
+      MOCK_OIDC_PUBLIC_KEY: "CHANGEME"
+      MOCK_OIDC_PRIVATE_KEY: "CHANGEME"
+    healthcheck:
+      test: ["CMD-SHELL", "nc", "-z", "localhost", "4000"]
+      interval: 5s
+      timeout: 2s
+      retries: 5


### PR DESCRIPTION
fixes #104 

Important:

- both the deliver application and the mock-oidc-server need to be available to the end user
- the deliver application needs to connect to the mock-oidc-server for token validation
- within a docker network, this means two kinds of access:
  - from host to container (via port mapping)
  - from container (deliver) to container (mock-oidc-server)
- port mapping provides access for the end user as `localhost:<mapped-port>`
- automatic network bridged mode provides access from container to container via `<container-name>: <port>`. So if the oidc server is named `oidc`, it is available as `http://oidc:4000` to the deliver application. This is problematic, as it cannot provide this as the authentication endpoint to the end user ("go to http://oidc:4000/auth" -> whoops this only works for me). I tried using the network mode "host", which uses the host network, but that does not work on mac (docker desktop runs within a VM!). So I ended up, proxying "localhost:4000" to "oidc:4000" with "caddy", so the deliver application could access it the same way the end user can. Better ideas?