### PR TITLE
expiry date should be now plus 31 days instead of now plus number of days of current month 

### DIFF
--- a/handlers/folders.go
+++ b/handlers/folders.go
@@ -48,7 +48,7 @@ func CreateFolder(w http.ResponseWriter, r *http.Request) {
 	folder := &models.Folder{
 		SpaceID:   space.ID,
 		Name:      b.Name,
-		ExpiresAt: time.Now().AddDate(0, 1, 0),
+		ExpiresAt: time.Now().AddDate(0, 0, 31),
 	}
 
 	if err := c.Repo.Folders.Create(r.Context(), folder); err != nil {

--- a/models/folder.go
+++ b/models/folder.go
@@ -56,6 +56,6 @@ func (f *Folder) Fake(faker *gofakeit.Faker) (any, error) {
 		Name:      fmt.Sprintf("%d", gofakeit.Number(1234567, 9123456)),
 		CreatedAt: created,
 		UpdatedAt: gofakeit.DateRange(created, time.Now()),
-		ExpiresAt: created.AddDate(0, 1, 0),
+		ExpiresAt: created.AddDate(0, 0, 31),
 	}, nil
 }


### PR DESCRIPTION
Set expiry date of files in S3 to `now + 31 days`.

Was set previously to `now + 1 month`, but the implementation
of `AddDate(year, month, days)` interprets month as number of
days in the current month, and then adds that number of days.
So if you upload in Februari, you have day less, and each four
years, you have two days less.

Makes it more testable too to set it to a fixed number of days.