### PR TITLE
Remove autocomplete from folder search

### DIFF
--- a/views/show_space.templ
+++ b/views/show_space.templ
@@ -124,6 +124,7 @@ templ ShowSpace(c *ctx.Ctx, space *models.Space, folders []*models.Folder, q str
 										hx-trigger="input changed delay:500ms, search"
 										hx-target="#folders"
 										hx-swap="innerHTML"
+										autocomplete="off"
 									/>
 									<label class="visually-hidden" for="q">Search</label>
 									<button class="btn btn-outline-primary" type="submit">

--- a/views/show_space.templ
+++ b/views/show_space.templ
@@ -120,11 +120,11 @@ templ ShowSpace(c *ctx.Ctx, space *models.Space, folders []*models.Folder, q str
 										id="q"
 										name="q"
 										value={ q }
+										autocomplete="off"
 										hx-get={ c.PathTo("getFolders", "spaceName", space.Name).String() }
 										hx-trigger="input changed delay:500ms, search"
 										hx-target="#folders"
 										hx-swap="innerHTML"
-										autocomplete="off"
 									/>
 									<label class="visually-hidden" for="q">Search</label>
 									<button class="btn btn-outline-primary" type="submit">

--- a/views/show_space_templ.go
+++ b/views/show_space_templ.go
@@ -234,7 +234,7 @@ func ShowSpace(c *ctx.Ctx, space *models.Space, folders []*models.Folder, q stri
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("\" hx-trigger=\"input changed delay:500ms, search\" hx-target=\"#folders\" hx-swap=\"innerHTML\"> <label class=\"visually-hidden\" for=\"q\">Search</label> <button class=\"btn btn-outline-primary\" type=\"submit\"><i class=\"if if-search\"></i><div class=\"btn-text\">Search</div></button></div></div></div></div></form><div id=\"folders\">")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("\" hx-trigger=\"input changed delay:500ms, search\" hx-target=\"#folders\" hx-swap=\"innerHTML\" autocomplete=\"off\"> <label class=\"visually-hidden\" for=\"q\">Search</label> <button class=\"btn btn-outline-primary\" type=\"submit\"><i class=\"if if-search\"></i><div class=\"btn-text\">Search</div></button></div></div></div></div></form><div id=\"folders\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/views/show_space_templ.go
+++ b/views/show_space_templ.go
@@ -226,7 +226,7 @@ func ShowSpace(c *ctx.Ctx, space *models.Space, folders []*models.Folder, q stri
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("\" hx-get=\"")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("\" autocomplete=\"off\" hx-get=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -234,7 +234,7 @@ func ShowSpace(c *ctx.Ctx, space *models.Space, folders []*models.Folder, q stri
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("\" hx-trigger=\"input changed delay:500ms, search\" hx-target=\"#folders\" hx-swap=\"innerHTML\" autocomplete=\"off\"> <label class=\"visually-hidden\" for=\"q\">Search</label> <button class=\"btn btn-outline-primary\" type=\"submit\"><i class=\"if if-search\"></i><div class=\"btn-text\">Search</div></button></div></div></div></div></form><div id=\"folders\">")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("\" hx-trigger=\"input changed delay:500ms, search\" hx-target=\"#folders\" hx-swap=\"innerHTML\"> <label class=\"visually-hidden\" for=\"q\">Search</label> <button class=\"btn btn-outline-primary\" type=\"submit\"><i class=\"if if-search\"></i><div class=\"btn-text\">Search</div></button></div></div></div></div></form><div id=\"folders\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}


### PR DESCRIPTION
Minor fix. As folder names are usually unique and disappear overtime, autocomplete in search is confusing and superfluous.