### PR TITLE
fix issue 122

### DIFF
--- a/cli/seed_cmd.go
+++ b/cli/seed_cmd.go
@@ -48,9 +48,11 @@ var seedCmd = &cobra.Command{
 			}
 		}
 
+		faker := gofakeit.New(0)
+
 		// Create a 'deliver' user
 		var user models.User
-		gofakeit.Struct(&user)
+		faker.Struct(&user)
 
 		if err := repo.Users.CreateOrUpdate(ctx, &user); err != nil {
 			return err
@@ -59,7 +61,7 @@ var seedCmd = &cobra.Command{
 		// Create a space
 		for i := 0; i < 5; i++ {
 			var space models.Space
-			gofakeit.Struct(&space)
+			faker.Struct(&space)
 
 			if err := repo.Spaces.Create(ctx, &space); err != nil {
 				return err
@@ -68,7 +70,7 @@ var seedCmd = &cobra.Command{
 			for j := 0; j < 5; j++ {
 				// Create a folder
 				var folder models.Folder
-				gofakeit.Struct(&folder)
+				faker.Struct(&folder)
 				folder.SpaceID = space.ID
 
 				if err := repo.Folders.Create(ctx, &folder); err != nil {
@@ -78,12 +80,12 @@ var seedCmd = &cobra.Command{
 				for k := 0; k < 5; k++ {
 					// Create a file
 					var file models.File
-					gofakeit.Struct(&file)
+					faker.Struct(&file)
 
 					file.FolderID = folder.ID
 					file.ID = ulid.Make().String()
 
-					ba := gofakeit.ImageJpeg(1024, 1024)
+					ba := faker.ImageJpeg(1024, 1024)
 					br := bytes.NewReader(ba)
 					rc := io.NopCloser(br)
 

--- a/models/folder.go
+++ b/models/folder.go
@@ -59,11 +59,11 @@ func (f *Folder) PostponeExpiration() time.Time {
 }
 
 func (f *Folder) Fake(faker *gofakeit.Faker) (any, error) {
-	created := gofakeit.PastDate()
+	created := faker.PastDate()
 	return Folder{
-		Name:      fmt.Sprintf("%d", gofakeit.Number(1234567, 9123456)),
+		Name:      fmt.Sprintf("%d", faker.Number(1234567, 9123456)),
 		CreatedAt: created,
-		UpdatedAt: gofakeit.DateRange(created, time.Now()),
+		UpdatedAt: faker.DateRange(created, time.Now()),
 		ExpiresAt: created.Add(PostponePeriod),
 	}, nil
 }

--- a/models/space.go
+++ b/models/space.go
@@ -28,7 +28,10 @@ func (s *Space) Validate() error {
 
 func (s *Space) Fake(faker *gofakeit.Faker) (any, error) {
 	return Space{
-		Name:   fmt.Sprintf("SPACE%09d", faker.Number(1234567, 9123456)),
+		Name: fmt.Sprintf("%s%09d",
+			faker.RandomString([]string{"BIBXYZ", "ABCLIB", "DEFCOL", "UNIZXY", "department", "BIBLIB", "FACLIB"}),
+			faker.Number(1234567, 9123456),
+		),
 		Admins: []string{"deliver"},
 	}, nil
 }

--- a/models/space.go
+++ b/models/space.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/brianvoe/gofakeit/v6"
@@ -27,7 +28,7 @@ func (s *Space) Validate() error {
 
 func (s *Space) Fake(faker *gofakeit.Faker) (any, error) {
 	return Space{
-		Name:   gofakeit.RandomString([]string{"BIBXYZ", "ABCLIB", "DEFCOL", "UNIZXY", "department", "BIBLIB", "FACLIB"}),
+		Name:   fmt.Sprintf("SPACE%09d", faker.Number(1234567, 9123456)),
 		Admins: []string{"deliver"},
 	}, nil
 }


### PR DESCRIPTION
fixes #122 

* random spaces are now generated as `SPACE` followed by a random number (with padding)
* I also replaced the global function calls inside the `Fake` methods (like `gofakeit.Number`) by a call on the supplied faker object. That was already done on some places. This way the same random generator is used every. e.g. `gofakeit.Number` uses a global random generator, so if you want to initiate the faker object with your chosen random generator, then it works everywhere in the same way
* initialised faker object explicitly in the seed command directly